### PR TITLE
Update to 1.21.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
         exclude(group: "net.fabricmc.fabric-api")
     }
 
-    implementation("de.bluecolored.bluemap:BlueMapAPI:2.7.2")
+    implementation(de.bluecolored:bluemap-api:2.7.3")
     modRuntimeOnly("maven.modrinth:bluemap:5.2-fabric-1.21")
 
     include(implementation("org.quiltmc.qup:json:0.2.0"))

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
         exclude(group: "net.fabricmc.fabric-api")
     }
 
-    implementation("de.bluecolored.bluemap:BlueMapAPI:2.7.3")
+    implementation("de.bluecolored.bluemap:BlueMapAPI:2.7.2")
     modRuntimeOnly("maven.modrinth:bluemap:5.2-fabric-1.21")
 
     include(implementation("org.quiltmc.qup:json:0.2.0"))

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.6-SNAPSHOT'
+    id 'fabric-loom' version '1.7-SNAPSHOT'
     id 'io.github.juuxel.loom-quiltflower' version '1.8.0'
     id 'maven-publish'
 }
@@ -42,21 +42,21 @@ dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings(loom.layered {
         officialMojangMappings()
-        parchment("org.parchmentmc.data:parchment-1.20.1:2023.09.03@zip")
+        parchment("org.parchmentmc.data:parchment-1.21:2024.07.28@zip")
     })
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
     // Fabric API. This is technically optional, but you probably want it anyway.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-    modImplementation("maven.modrinth:open-parties-and-claims:fabric-1.20.1-0.22.0")
+    modImplementation("maven.modrinth:open-parties-and-claims:fabric-1.21-0.23.2")
     modRuntimeOnly("fuzs.forgeconfigapiport:forgeconfigapiport-fabric:8.0.0") {
         exclude(group: "net.fabricmc")
         exclude(group: "net.fabricmc.fabric-api")
     }
 
-    implementation("de.bluecolored.bluemap:BlueMapAPI:2.7.1")
-    modRuntimeOnly("maven.modrinth:bluemap:3.20-fabric-1.20")
+    implementation("de.bluecolored.bluemap:BlueMapAPI:2.7.2")
+    modRuntimeOnly("maven.modrinth:bluemap:5.4-fabric-1.21")
 
     include(implementation("org.quiltmc.qup:json:0.2.0"))
 }
@@ -70,7 +70,7 @@ processResources {
     }
 }
 
-def targetJavaVersion = 17
+def targetJavaVersion = 21
 tasks.withType(JavaCompile).configureEach {
     // ensure that the encoding is set to UTF-8, no matter what the system default is
     // this fixes some edge cases with special characters not displaying correctly

--- a/build.gradle
+++ b/build.gradle
@@ -49,14 +49,14 @@ dependencies {
     // Fabric API. This is technically optional, but you probably want it anyway.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-    modImplementation("maven.modrinth:open-parties-and-claims:fabric-1.21-0.23.2")
+    modImplementation("maven.modrinth:open-parties-and-claims:fabric-1.21-0.23.1")
     modRuntimeOnly("fuzs.forgeconfigapiport:forgeconfigapiport-fabric:8.0.0") {
         exclude(group: "net.fabricmc")
         exclude(group: "net.fabricmc.fabric-api")
     }
 
-    implementation("de.bluecolored.bluemap:BlueMapAPI:2.7.2")
-    modRuntimeOnly("maven.modrinth:bluemap:5.4-fabric-1.21")
+    implementation("de.bluecolored.bluemap:BlueMapAPI:2.7.3")
+    modRuntimeOnly("maven.modrinth:bluemap:5.2-fabric-1.21")
 
     include(implementation("org.quiltmc.qup:json:0.2.0"))
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,6 @@ org.gradle.jvmargs=-Xmx1G
 	minecraft_version=1.21.1
 	minecraft_version_range=>=1.21 <1.22
 	loader_version=0.15.11
-	loader_version_range=>=0.14
 
 # Mod Properties
 	mod_version = 1.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	# check this on https://modmuss50.me/fabric.html
-	fabric_version=0.102.0+1.21.1
+	fabric_version=0.100.1+1.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,16 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://modmuss50.me/fabric.html
-	minecraft_version=1.20.1
-	loader_version=0.15.9
+	minecraft_version=1.21.1
+	minecraft_version_range=>=1.21 <1.22
+	loader_version=0.15.11
+	loader_version_range=>=0.14
 
 # Mod Properties
-	mod_version = 1.0.3
+	mod_version = 1.1.0
 	maven_group = io.github.gaming32
 	archives_base_name = opac-bluemap-integration
 
 # Dependencies
 	# check this on https://modmuss50.me/fabric.html
-	fabric_version=0.91.1+1.20.1
+	fabric_version=0.102.0+1.21.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	# check this on https://modmuss50.me/fabric.html
-	fabric_version=0.100.1+1.21
+	fabric_version=0.102.0+1.21.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/io/github/gaming32/opacbluemapintegration/OpacBluemapIntegration.java
+++ b/src/main/java/io/github/gaming32/opacbluemapintegration/OpacBluemapIntegration.java
@@ -216,7 +216,7 @@ public class OpacBluemapIntegration implements ModInitializer {
                                 flatPlane
                                     ? ShapeMarker.builder()
                                         .label(displayName)
-                                        .fillColor(new Color(playerClaimInfo.getClaimsColor(), 150))
+                                        .fillColor(new Color(playerClaimInfo.getClaimsColor(), 102))
                                         .lineColor(new Color(playerClaimInfo.getClaimsColor(), 255))
                                         .shape(shape.baseShape(), minY)
                                         .holes(shape.holes())
@@ -224,7 +224,7 @@ public class OpacBluemapIntegration implements ModInitializer {
                                         .build()
                                     : ExtrudeMarker.builder()
                                         .label(displayName)
-                                        .fillColor(new Color(playerClaimInfo.getClaimsColor(), 150))
+                                        .fillColor(new Color(playerClaimInfo.getClaimsColor(), 102))
                                         .lineColor(new Color(playerClaimInfo.getClaimsColor(), 255))
                                         .shape(shape.baseShape(), minY, maxY)
                                         .holes(shape.holes())

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,8 +25,8 @@
   "depends": {
     "fabricloader": ">=0.14.0",
     "fabric": "*",
-    "minecraft": ">=1.20.1",
-    "bluemap": ">=3.13",
-    "openpartiesandclaims": ">=0.17.6"
+    "minecraft": ">=1.21",
+    "bluemap": ">=5.2",
+    "openpartiesandclaims": ">=0.23.1"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,7 +23,7 @@
     "opac-bluemap-integration.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.14.0",
+    "fabricloader": ">=0.15.11",
     "fabric": "*",
     "minecraft": ">=1.21",
     "bluemap": ">=5.2",


### PR DESCRIPTION
Simple update to 1.21.1 (separate branch). Unfortunately, it still relies on 10 minute refreshes (including after server start) instead of detecting OpenPAC claims and unclaims (if possible? Exists but not entirely sure if their API allows for that possibility). Can download update [here](https://github.com/lesCrayons/opac-bluemap-integration/releases/tag/1.1.0) in the meantime.